### PR TITLE
Added Route to Get the Number of Hearts Received

### DIFF
--- a/models/heart.go
+++ b/models/heart.go
@@ -26,6 +26,9 @@ type FetchHeartsFirst struct {
 	Enc            string `json:"enc"`
 	GenderOfSender string `json:"genderOfSender"`
 }
+type sentHeartsDecoded struct {
+	DecodedHearts []FetchHeartsFirst `json:"decodedHearts" binding:"required"`
+}
 
 // gorm.Model represents the structure of our resource in db
 type (

--- a/router/router.go
+++ b/router/router.go
@@ -25,6 +25,7 @@ func PuppyRoute(r *gin.Engine, db db.PuppyDb) {
 		users.Use(controllers.AuthenticateUser())
 		users.GET("/fetchPublicKeys", controllers.FetchPublicKeys)
 		users.GET("/fetchall", controllers.FetchHearts)
+		users.POST("/sentHeartDecoded", controllers.sentHeartDecoded)
 		// users.GET("/fetchreturnhearts", controllers.FetchReturnHearts)
 		users.POST("/sendheart", controllers.SendHeart)
 		users.POST("/claimheart", controllers.HeartClaim)


### PR DESCRIPTION
First, make a GET request to /fetchall
It would return the Encrypted SHAs (that has to be decrypted using the private key of the user at the front-end)
Then the decrypted values has to be sent to /sentHeartDecoded via POST request with JSON data in the format as given:
{"DecodedHearts": [{"enc": decoded_using_private_key, "genderOfSender": genderOfSender}, ...]
And the order should be the same as received
It would return the number of matches from each gender, in the format
{"male": heartsReceivedFromMales, "female": heartsReceivedFromFemales}